### PR TITLE
dlnproof / c-split exploit remediation

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,7 +21,8 @@ jobs:
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: 'yes'
-          config-file: '.github/workflows/mlc_config.json'
+          use-verbose-mode: 'yes'
+          check-modified-files-only: 'yes'
   # ensures build succeeds without warnings
   cargo-check:
     name: build

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/checkout@v2
       - uses: hecrj/setup-rust-action@v1
-      - run: cargo check --workspace --verbose --no-default-features
+      - run: cargo check --workspace --verbose
   # ensures proper formatting and clippy lint
   lint-check:
     name: lint

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,19 +10,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  # checks markdown links
-  link-check:
-    name: links
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Check markdown links
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
-        with:
-          use-quiet-mode: 'yes'
-          use-verbose-mode: 'yes'
-          check-modified-files-only: 'yes'
   # ensures build succeeds without warnings
   cargo-check:
     name: build

--- a/src/party_i.rs
+++ b/src/party_i.rs
@@ -144,7 +144,7 @@ pub fn generate_h1_h2_N_tilde() -> (BigInt, BigInt, BigInt, BigInt, BigInt) {
 	// let (ek_tilde, dk_tilde) = Paillier::keypair().keys();
 	let one = BigInt::one();
 	let phi = (&dk_tilde.p - &one) * (&dk_tilde.q - &one);
-	let (mut xhi, mut xhi_inv) = loop {
+	let (xhi, xhi_inv) = loop {
 		let xhi_ = BigInt::sample_below(&phi);
 		match BigInt::mod_inv(&xhi_, &phi) {
 			Some(inv) => break (xhi_, inv),

--- a/src/party_i.rs
+++ b/src/party_i.rs
@@ -156,6 +156,7 @@ pub fn generate_h1_h2_N_tilde() -> (BigInt, BigInt, BigInt, BigInt, BigInt) {
 	xhi = BigInt::sub(&phi, &xhi);
 	xhi_inv = BigInt::sub(&phi, &xhi_inv);
 
+	// xhi ~ alpha, xhi_inv ~ beta (as specified in binance tss-lib)
 	(ek_tilde.n, h1, h2, xhi, xhi_inv)
 }
 

--- a/src/party_i.rs
+++ b/src/party_i.rs
@@ -140,8 +140,8 @@ pub struct SignatureRecid {
 
 pub fn generate_h1_h2_N_tilde() -> (BigInt, BigInt, BigInt, BigInt, BigInt) {
 	// note, should be safe primes:
-	// let (ek_tilde, dk_tilde) = Paillier::keypair_safe_primes().keys();;
-	let (ek_tilde, dk_tilde) = Paillier::keypair().keys();
+	let (ek_tilde, dk_tilde) = Paillier::keypair_safe_primes().keys();
+	// let (ek_tilde, dk_tilde) = Paillier::keypair().keys();
 	let one = BigInt::one();
 	let phi = (&dk_tilde.p - &one) * (&dk_tilde.q - &one);
 	let h1 = BigInt::sample_below(&ek_tilde.n);

--- a/src/party_i.rs
+++ b/src/party_i.rs
@@ -144,7 +144,6 @@ pub fn generate_h1_h2_N_tilde() -> (BigInt, BigInt, BigInt, BigInt, BigInt) {
 	// let (ek_tilde, dk_tilde) = Paillier::keypair().keys();
 	let one = BigInt::one();
 	let phi = (&dk_tilde.p - &one) * (&dk_tilde.q - &one);
-	let h1 = BigInt::sample_below(&ek_tilde.n);
 	let (mut xhi, mut xhi_inv) = loop {
 		let xhi_ = BigInt::sample_below(&phi);
 		match BigInt::mod_inv(&xhi_, &phi) {
@@ -152,9 +151,10 @@ pub fn generate_h1_h2_N_tilde() -> (BigInt, BigInt, BigInt, BigInt, BigInt) {
 			None => continue,
 		}
 	};
+	let h1 = BigInt::sample_below(&ek_tilde.n);
 	let h2 = BigInt::mod_pow(&h1, &xhi, &ek_tilde.n);
-	xhi = BigInt::sub(&phi, &xhi);
-	xhi_inv = BigInt::sub(&phi, &xhi_inv);
+	// xhi = BigInt::sub(&phi, &xhi);
+	// xhi_inv = BigInt::sub(&phi, &xhi_inv);
 
 	// xhi ~ alpha, xhi_inv ~ beta (as specified in binance tss-lib)
 	(ek_tilde.n, h1, h2, xhi, xhi_inv)

--- a/src/presign/mod.rs
+++ b/src/presign/mod.rs
@@ -37,8 +37,8 @@ use crate::utilities::{
 	mul::{PaillierMulProof, PaillierMulStatement},
 };
 
+use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
-use serde::{Serialize, Deserialize};
 
 pub mod rounds;
 pub mod state_machine;

--- a/src/presign/state_machine.rs
+++ b/src/presign/state_machine.rs
@@ -515,10 +515,9 @@ pub mod test {
 	pub fn extract_secret_key(local_keys: &[LocalKey<Secp256k1>]) -> Scalar<Secp256k1> {
 		let secret_shares: Vec<Scalar<Secp256k1>> =
 			local_keys.iter().map(|key| key.keys_linear.x_i.clone()).collect();
-		local_keys[0].vss_scheme.reconstruct(
-			&(0..local_keys.len() as u16).collect::<Vec<u16>>(),
-			&secret_shares.clone(),
-		)
+		local_keys[0]
+			.vss_scheme
+			.reconstruct(&(0..local_keys.len() as u16).collect::<Vec<u16>>(), &secret_shares)
 	}
 
 	pub fn extract_k(

--- a/src/presign/state_machine.rs
+++ b/src/presign/state_machine.rs
@@ -30,8 +30,8 @@ use round_based::{
 	IsCritical, Msg, StateMachine,
 };
 
+use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt, mem::replace, time::Duration};
-use serde::{Serialize, Deserialize};
 use thiserror::Error;
 
 // NOTE: This is a hack since in the 1st round we will need to broadcast and send P2P

--- a/src/refresh/rounds.rs
+++ b/src/refresh/rounds.rs
@@ -97,13 +97,7 @@ impl Round1 {
 		mut output: O,
 	) -> Result<Round2>
 	where
-		O: Push<
-			Msg<
-				Option<
-				    RefreshMessage<Secp256k1, Sha256, { crate::utilities::STAT_PARAM }>,
-				>,
-			>,
-		>,
+		O: Push<Msg<Option<RefreshMessage<Secp256k1, Sha256, { crate::utilities::STAT_PARAM }>>>>,
 	{
 		let join_message_option_vec = input.into_vec();
 		let mut join_message_vec: Vec<
@@ -191,9 +185,7 @@ impl Round2 {
 	pub fn proceed(
 		self,
 		input: BroadcastMsgs<
-			Option<
-				RefreshMessage<Secp256k1, Sha256, { crate::utilities::STAT_PARAM }>,
-			>,
+			Option<RefreshMessage<Secp256k1, Sha256, { crate::utilities::STAT_PARAM }>>,
 		>,
 	) -> Result<LocalKey<Secp256k1>> {
 		let refresh_message_option_vec = input.into_vec_including_me(self.refresh_message);

--- a/src/refresh/state_machine.rs
+++ b/src/refresh/state_machine.rs
@@ -1,13 +1,9 @@
 use crate::refresh::rounds::{Round0, Round1, Round2};
 
 use curv::elliptic::curves::Secp256k1;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
-use fs_dkr::{
-	add_party_message::JoinMessage,
-	error::FsDkrError,
-	refresh_message::RefreshMessage,
-};
+use fs_dkr::{add_party_message::JoinMessage, error::FsDkrError, refresh_message::RefreshMessage};
 use multi_party_ecdsa::protocols::multi_party_ecdsa::gg_2020::state_machine::keygen::LocalKey;
 use private::InternalError;
 use round_based::{
@@ -26,9 +22,7 @@ use thiserror::Error;
 pub type Round0Messages =
 	Store<BroadcastMsgs<Option<JoinMessage<Secp256k1, Sha256, { crate::utilities::STAT_PARAM }>>>>;
 pub type Round1Messages = Store<
-	BroadcastMsgs<
-		Option<RefreshMessage<Secp256k1, Sha256, { crate::utilities::STAT_PARAM }>>,
-	>,
+	BroadcastMsgs<Option<RefreshMessage<Secp256k1, Sha256, { crate::utilities::STAT_PARAM }>>>,
 >;
 
 pub struct KeyRefresh {
@@ -330,9 +324,7 @@ pub struct ProtocolMessage(M);
 #[derive(Debug, Clone, Serialize, Deserialize)]
 enum M {
 	Round1(Option<JoinMessage<Secp256k1, Sha256, { crate::utilities::STAT_PARAM }>>),
-	Round2(
-	    Option<RefreshMessage<Secp256k1, Sha256, { crate::utilities::STAT_PARAM }>>,
-	),
+	Round2(Option<RefreshMessage<Secp256k1, Sha256, { crate::utilities::STAT_PARAM }>>),
 }
 
 // Error

--- a/src/sign/mod.rs
+++ b/src/sign/mod.rs
@@ -16,7 +16,7 @@
 use std::collections::HashMap;
 
 use curv::{elliptic::curves::Curve, BigInt};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use sha2::Sha256;
 

--- a/src/sign/state_machine.rs
+++ b/src/sign/state_machine.rs
@@ -30,8 +30,8 @@ use round_based::{
 	},
 	IsCritical, Msg, StateMachine,
 };
+use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt, mem::replace, time::Duration};
-use serde::{Serialize, Deserialize};
 use thiserror::Error;
 
 // NOTE: This is a hack since in the 1st round we will need to broadcast and send P2P

--- a/src/utilities/dlnproof/mod.rs
+++ b/src/utilities/dlnproof/mod.rs
@@ -190,14 +190,13 @@ impl DlnProof {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::utilities::{mta::range_proofs::SampleFromMultiplicativeGroup, BITS_PAILLIER};
 	use curv::elliptic::curves::{secp256_k1::Secp256k1, Scalar};
 	use paillier::{KeyGeneration, Paillier};
 	use sha2::Sha512Trunc256;
 
 	#[test]
 	fn test_discrete_log_proof() {
-		let ((s1, w1), (s2, w2)) = DlnProofStatement::generate();
+		let ((s1, w1), _) = DlnProofStatement::generate();
 		let proof = DlnProof::prove(&w1, &s1);
 		let result = proof.verify(&s1);
 		assert!(result.is_ok());

--- a/src/utilities/dlnproof/mod.rs
+++ b/src/utilities/dlnproof/mod.rs
@@ -3,13 +3,11 @@
 use curv::{
 	arithmetic::traits::*,
 	cryptographic_primitives::hashing::{Digest, DigestExt},
-	elliptic::curves::{secp256_k1::Secp256k1, Point, Scalar},
 	BigInt,
 };
-use fs_dkr::PAILLIER_KEY_SIZE;
-use paillier::{EncryptionKey, Paillier};
+
 use serde::{Deserialize, Serialize};
-use sha2::{Sha256, Sha512Trunc256};
+use sha2::Sha512Trunc256;
 use thiserror::Error;
 
 use crate::party_i::Keys;
@@ -24,22 +22,40 @@ pub enum DlnProofError {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DlnProofStatement {
-	pub ek: EncryptionKey,
 	pub h1: BigInt,
 	pub h2: BigInt,
-	pub N_tilde: BigInt,
+	pub N: BigInt,
 }
 
 impl DlnProofStatement {
-	pub fn generate() -> Self {
+	/// Generate a discrete logarithm proof statement
+	///
+	/// Following from https://github.com/bnb-chain/tss-lib/blob/master/ecdsa/keygen/round_1.go#L86-L96
+	/// we generate two statements to prove that both h1,h2 generate the same group mod N
+	pub fn generate() -> ((Self, DlnProofWitness), (Self, DlnProofWitness)) {
 		let key = Keys::create(0);
-		DlnProofStatement { ek: key.ek, h1: key.h1, h2: key.h2, N_tilde: key.N_tilde }
+		(
+			(
+				DlnProofStatement {
+					h1: key.h1.clone(),
+					h2: key.h2.clone(),
+					N: key.N_tilde.clone(),
+				},
+				DlnProofWitness { x: key.xhi, p: key.dk.p.clone(), q: key.dk.q.clone() },
+			),
+			(
+				DlnProofStatement { h1: key.h2, h2: key.h1, N: key.N_tilde },
+				DlnProofWitness { x: key.xhi_inv, p: key.dk.p, q: key.dk.q },
+			),
+		)
 	}
 }
 
 #[derive(Clone)]
 pub struct DlnProofWitness {
 	pub x: BigInt,
+	pub p: BigInt,
+	pub q: BigInt,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -50,21 +66,20 @@ pub struct DlnProof {
 
 impl DlnProof {
 	pub fn prove(witness: &DlnProofWitness, statement: &DlnProofStatement) -> Self {
+		let p_mul_q = BigInt::mul(&witness.p, &witness.q);
 		let mut a: Vec<BigInt> = vec![BigInt::zero(); ITERATIONS];
 		let mut alpha: Vec<BigInt> = vec![BigInt::zero(); ITERATIONS];
 		for i in 0..ITERATIONS {
-			a[i] = BigInt::sample_below(&statement.ek.n);
-			alpha[i] = BigInt::mod_pow(&statement.h1, &a[i], &statement.N_tilde);
+			a[i] = BigInt::sample_below(&p_mul_q);
+			alpha[i] = BigInt::mod_pow(&statement.h1, &a[i], &statement.N);
 		}
 
-		let mut msg: Vec<&BigInt> = vec![&statement.h1, &statement.h2, &statement.N_tilde];
+		let mut hash = Sha512Trunc256::new()
+			.chain_bigint(&statement.h1)
+			.chain_bigint(&statement.h2)
+			.chain_bigint(&statement.N);
 		for i in 0..ITERATIONS {
-			msg.push(&alpha[i]);
-		}
-
-		let mut hash = Sha512Trunc256::new();
-		for elt in msg.iter() {
-			hash = hash.chain_bigint(&elt);
+			hash = hash.chain_bigint(&alpha[i]);
 		}
 
 		let c: Vec<_> = hash
@@ -89,55 +104,56 @@ impl DlnProof {
 		let mut t: Vec<BigInt> = vec![BigInt::zero(); ITERATIONS];
 		for i in 0..ITERATIONS {
 			let c_i = BigInt::from(c[i] as u16);
-			let rhs = BigInt::mod_mul(&c_i, &witness.x, &statement.ek.n);
-			t[i] = BigInt::mod_add(&a[i], &rhs, &statement.ek.n);
+			let rhs = BigInt::mod_mul(&c_i, &witness.x, &p_mul_q);
+			t[i] = BigInt::mod_add(&a[i], &rhs, &p_mul_q);
 		}
 
 		DlnProof { Alpha: alpha, T: t }
 	}
 
 	pub fn verify(&self, statement: &DlnProofStatement) -> Result<(), DlnProofError> {
-		println!("Verify h1 >= 1 and h1 < N_tilde");
-		if statement.h1 <= BigInt::one() || statement.h1 >= statement.N_tilde {
+		println!("Verify h1 >= 1 and h1 < N");
+		let h1 = statement.h1.mod_floor(&statement.N);
+		if h1 <= BigInt::one() || h1 >= statement.N {
 			return Err(DlnProofError::Verify)
 		}
 
-		println!("Verify h2 >= 1 and h2 < N_tilde");
-		if statement.h2 <= BigInt::one() || statement.h2 >= statement.N_tilde {
+		println!("Verify h2 >= 1 and h2 < N");
+		let h2 = statement.h2.mod_floor(&statement.N);
+		if h2 <= BigInt::one() || h2 >= statement.N {
 			return Err(DlnProofError::Verify)
 		}
 
 		println!("Verify h1 != h2");
-		if statement.h1 == statement.h2 {
+		if h1 == h2 {
 			return Err(DlnProofError::Verify)
 		}
 
-		println!("Verify all T_i >= 1 and T_i < N_tilde");
+		println!("Verify all T_i >= 1 and T_i < N");
 		for t in &self.T {
-			let a = t.mod_floor(&statement.N_tilde);
-			if a <= BigInt::one() || a >= statement.N_tilde {
+			let a = t.mod_floor(&statement.N);
+			if a <= BigInt::one() || a >= statement.N {
 				return Err(DlnProofError::Verify)
 			}
 		}
 
-		println!("Verify all Alpha_i >= 1 and Alpha_i < N_tilde");
+		println!("Verify all Alpha_i >= 1 and Alpha_i < N");
 		for alpha in &self.Alpha {
-			let a = alpha.mod_floor(&statement.N_tilde);
-			if a <= BigInt::one() || a >= statement.N_tilde {
+			let a = alpha.mod_floor(&statement.N);
+			if a <= BigInt::one() || a >= statement.N {
 				return Err(DlnProofError::Verify)
 			}
 		}
 
 		// Reconstruct the hash (challenge)
-		let mut msg: Vec<&BigInt> = vec![&statement.h1, &statement.h2, &statement.N_tilde];
+		let mut hash = Sha512Trunc256::new()
+			.chain_bigint(&h1)
+			.chain_bigint(&h2)
+			.chain_bigint(&statement.N);
 		for i in 0..ITERATIONS {
-			msg.push(&self.Alpha[i]);
+			hash = hash.chain_bigint(&self.Alpha[i]);
 		}
 
-		let mut hash = Sha512Trunc256::new();
-		for elt in msg.iter() {
-			hash = hash.chain_bigint(&elt);
-		}
 		let c: Vec<_> = hash
 			.result_bigint()
 			.to_bytes()
@@ -160,10 +176,9 @@ impl DlnProof {
 		// Validate the zero-knowledge proof
 		for i in 0..ITERATIONS {
 			let c_i = BigInt::from(c[i] as u16);
-			let h1_exp_t_i = BigInt::mod_pow(&statement.h1, &self.T[i], &statement.N_tilde);
-			let h2_exp_c_i = BigInt::mod_pow(&statement.h2, &c_i, &statement.N_tilde);
-			let alpha_i_mul_h2_exp_c_i =
-				BigInt::mod_mul(&self.Alpha[i], &h2_exp_c_i, &statement.N_tilde);
+			let h1_exp_t_i = BigInt::mod_pow(&h1, &self.T[i], &statement.N);
+			let h2_exp_c_i = BigInt::mod_pow(&h2, &c_i, &statement.N);
+			let alpha_i_mul_h2_exp_c_i = BigInt::mod_mul(&self.Alpha[i], &h2_exp_c_i, &statement.N);
 
 			println!("{:?}", i);
 			if h1_exp_t_i != alpha_i_mul_h2_exp_c_i {
@@ -179,17 +194,16 @@ impl DlnProof {
 mod tests {
 	use super::*;
 	use crate::utilities::{mta::range_proofs::SampleFromMultiplicativeGroup, BITS_PAILLIER};
-	use curv::elliptic::curves::secp256_k1::Secp256k1;
+	use curv::elliptic::curves::{secp256_k1::Secp256k1, Scalar};
 	use paillier::{KeyGeneration, Paillier};
 	use sha2::Sha512Trunc256;
 
 	#[test]
 	fn test_discrete_log_proof() {
-		let statement = DlnProofStatement::generate();
+		let ((s1, w1), (s2, w2)) = DlnProofStatement::generate();
 		let x = Scalar::<Secp256k1>::random();
-		let witness = DlnProofWitness { x: x.to_bigint() };
-		let proof = DlnProof::prove(&witness, &statement);
-		let result = proof.verify(&statement);
+		let proof = DlnProof::prove(&w1, &s1);
+		let result = proof.verify(&s1);
 		assert!(result.is_ok());
 	}
 }

--- a/src/utilities/dlnproof/mod.rs
+++ b/src/utilities/dlnproof/mod.rs
@@ -105,7 +105,7 @@ impl DlnProof {
 
 		let mut t: Vec<BigInt> = vec![BigInt::zero(); ITERATIONS];
 		for i in 0..ITERATIONS {
-			let c_i = BigInt::from(c[i] as u16);
+			let c_i = if c[i] == 0 { BigInt::zero() } else { BigInt::one() };
 			let rhs = BigInt::mod_mul(&c_i, &witness.x, &statement.N);
 			t[i] = BigInt::mod_add(&a[i], &rhs, &statement.N);
 
@@ -185,7 +185,7 @@ impl DlnProof {
 
 		// Validate the zero-knowledge proof
 		for i in 0..ITERATIONS {
-			let c_i = BigInt::from(c[i] as u16);
+			let c_i = if c[i] == 0 { BigInt::zero() } else { BigInt::one() };
 			let h1_exp_t_i = BigInt::mod_pow(&h1, &self.T[i], &statement.N);
 			let h2_exp_c_i = BigInt::mod_pow(&h2, &c_i, &statement.N);
 			let alpha_i_mul_h2_exp_c_i = BigInt::mod_mul(&self.Alpha[i], &h2_exp_c_i, &statement.N);

--- a/src/utilities/dlnproof/mod.rs
+++ b/src/utilities/dlnproof/mod.rs
@@ -85,7 +85,8 @@ impl DlnProof {
 		let digest = hash.result_bigint();
 		println!("Prover | Digest: {:?}", digest.to_bytes());
 
-		let c: Vec<_> = digest.to_bytes()
+		let c: Vec<_> = digest
+			.to_bytes()
 			.into_iter()
 			.flat_map(|val| {
 				[
@@ -113,7 +114,10 @@ impl DlnProof {
 			let alpha_i_mul_h2_exp_c_i = BigInt::mod_mul(&alpha[i], &h2_exp_c_i, &statement.N);
 			if h1_exp_t_i != alpha_i_mul_h2_exp_c_i {
 				println!("Prover {:?} {:?} | h1_exp_t_i: {:?}", i, c_i, h1_exp_t_i);
-				println!("Prover {:?} {:?} | alpha_i_mul_h2_exp_c_i: {:?}", i, c_i, alpha_i_mul_h2_exp_c_i);
+				println!(
+					"Prover {:?} {:?} | alpha_i_mul_h2_exp_c_i: {:?}",
+					i, c_i, alpha_i_mul_h2_exp_c_i
+				);
 			}
 		}
 
@@ -161,7 +165,8 @@ impl DlnProof {
 		let digest = hash.result_bigint();
 		println!("Verifier | Digest: {:?}", digest.to_bytes());
 
-		let c: Vec<_> = digest.to_bytes()
+		let c: Vec<_> = digest
+			.to_bytes()
 			.into_iter()
 			.flat_map(|val| {
 				[
@@ -187,7 +192,10 @@ impl DlnProof {
 
 			if h1_exp_t_i != alpha_i_mul_h2_exp_c_i {
 				println!("Verifier {:?} {:?} | h1_exp_t_i: {:?}", i, c_i, h1_exp_t_i);
-				println!("Verifier {:?} {:?} | alpha_i_mul_h2_exp_c_i: {:?}", i, c_i, alpha_i_mul_h2_exp_c_i);
+				println!(
+					"Verifier {:?} {:?} | alpha_i_mul_h2_exp_c_i: {:?}",
+					i, c_i, alpha_i_mul_h2_exp_c_i
+				);
 				return Err(DlnProofError::Verify)
 			}
 		}

--- a/src/utilities/dlnproof/mod.rs
+++ b/src/utilities/dlnproof/mod.rs
@@ -78,8 +78,8 @@ impl DlnProof {
 			.chain_bigint(&statement.h1)
 			.chain_bigint(&statement.h2)
 			.chain_bigint(&statement.N);
-		for i in 0..ITERATIONS {
-			hash = hash.chain_bigint(&alpha[i]);
+		for alpha_i in alpha.iter() {
+			hash = hash.chain_bigint(alpha_i);
 		}
 
 		let digest = hash.result_bigint();
@@ -97,7 +97,7 @@ impl DlnProof {
 					(val >> 3) & 1,
 					(val >> 2) & 1,
 					(val >> 1) & 1,
-					(val >> 0) & 1,
+					val & 1,
 				]
 				.into_iter()
 			})
@@ -177,15 +177,15 @@ impl DlnProof {
 					(val >> 3) & 1,
 					(val >> 2) & 1,
 					(val >> 1) & 1,
-					(val >> 0) & 1,
+					val & 1,
 				]
 				.into_iter()
 			})
 			.collect();
 
 		// Validate the zero-knowledge proof
-		for i in 0..ITERATIONS {
-			let c_i = if c[i] == 0 { BigInt::zero() } else { BigInt::one() };
+		for (i, c_val) in c.iter().enumerate().take(ITERATIONS) {
+			let c_i = if *c_val == 0u8 { BigInt::zero() } else { BigInt::one() };
 			let h1_exp_t_i = BigInt::mod_pow(&h1, &self.T[i], &statement.N);
 			let h2_exp_c_i = BigInt::mod_pow(&h2, &c_i, &statement.N);
 			let alpha_i_mul_h2_exp_c_i = BigInt::mod_mul(&self.Alpha[i], &h2_exp_c_i, &statement.N);

--- a/src/utilities/dlnproof/mod.rs
+++ b/src/utilities/dlnproof/mod.rs
@@ -1,0 +1,195 @@
+#![allow(non_snake_case)]
+
+use curv::{
+	arithmetic::traits::*,
+	cryptographic_primitives::hashing::{Digest, DigestExt},
+	elliptic::curves::{secp256_k1::Secp256k1, Point, Scalar},
+	BigInt,
+};
+use fs_dkr::PAILLIER_KEY_SIZE;
+use paillier::{EncryptionKey, Paillier};
+use serde::{Deserialize, Serialize};
+use sha2::{Sha256, Sha512Trunc256};
+use thiserror::Error;
+
+use crate::party_i::Keys;
+
+pub const ITERATIONS: usize = 128;
+
+#[derive(Error, Debug)]
+pub enum DlnProofError {
+	#[error("dlnproof verification failed")]
+	Verify,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DlnProofStatement {
+	pub ek: EncryptionKey,
+	pub h1: BigInt,
+	pub h2: BigInt,
+	pub N_tilde: BigInt,
+}
+
+impl DlnProofStatement {
+	pub fn generate() -> Self {
+		let key = Keys::create(0);
+		DlnProofStatement { ek: key.ek, h1: key.h1, h2: key.h2, N_tilde: key.N_tilde }
+	}
+}
+
+#[derive(Clone)]
+pub struct DlnProofWitness {
+	pub x: BigInt,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DlnProof {
+	Alpha: Vec<BigInt>,
+	T: Vec<BigInt>,
+}
+
+impl DlnProof {
+	pub fn prove(witness: &DlnProofWitness, statement: &DlnProofStatement) -> Self {
+		let mut a: Vec<BigInt> = vec![BigInt::zero(); ITERATIONS];
+		let mut alpha: Vec<BigInt> = vec![BigInt::zero(); ITERATIONS];
+		for i in 0..ITERATIONS {
+			a[i] = BigInt::sample_below(&statement.ek.n);
+			alpha[i] = BigInt::mod_pow(&statement.h1, &a[i], &statement.N_tilde);
+		}
+
+		let mut msg: Vec<&BigInt> = vec![&statement.h1, &statement.h2, &statement.N_tilde];
+		for i in 0..ITERATIONS {
+			msg.push(&alpha[i]);
+		}
+
+		let mut hash = Sha512Trunc256::new();
+		for elt in msg.iter() {
+			hash = hash.chain_bigint(&elt);
+		}
+
+		let c: Vec<_> = hash
+			.result_bigint()
+			.to_bytes()
+			.into_iter()
+			.flat_map(|val| {
+				[
+					(val >> 7) & 1,
+					(val >> 6) & 1,
+					(val >> 5) & 1,
+					(val >> 4) & 1,
+					(val >> 3) & 1,
+					(val >> 2) & 1,
+					(val >> 1) & 1,
+					(val >> 0) & 1,
+				]
+				.into_iter()
+			})
+			.collect();
+
+		let mut t: Vec<BigInt> = vec![BigInt::zero(); ITERATIONS];
+		for i in 0..ITERATIONS {
+			let c_i = BigInt::from(c[i] as u16);
+			let rhs = BigInt::mod_mul(&c_i, &witness.x, &statement.ek.n);
+			t[i] = BigInt::mod_add(&a[i], &rhs, &statement.ek.n);
+		}
+
+		DlnProof { Alpha: alpha, T: t }
+	}
+
+	pub fn verify(&self, statement: &DlnProofStatement) -> Result<(), DlnProofError> {
+		println!("Verify h1 >= 1 and h1 < N_tilde");
+		if statement.h1 <= BigInt::one() || statement.h1 >= statement.N_tilde {
+			return Err(DlnProofError::Verify)
+		}
+
+		println!("Verify h2 >= 1 and h2 < N_tilde");
+		if statement.h2 <= BigInt::one() || statement.h2 >= statement.N_tilde {
+			return Err(DlnProofError::Verify)
+		}
+
+		println!("Verify h1 != h2");
+		if statement.h1 == statement.h2 {
+			return Err(DlnProofError::Verify)
+		}
+
+		println!("Verify all T_i >= 1 and T_i < N_tilde");
+		for t in &self.T {
+			let a = t.mod_floor(&statement.N_tilde);
+			if a <= BigInt::one() || a >= statement.N_tilde {
+				return Err(DlnProofError::Verify)
+			}
+		}
+
+		println!("Verify all Alpha_i >= 1 and Alpha_i < N_tilde");
+		for alpha in &self.Alpha {
+			let a = alpha.mod_floor(&statement.N_tilde);
+			if a <= BigInt::one() || a >= statement.N_tilde {
+				return Err(DlnProofError::Verify)
+			}
+		}
+
+		// Reconstruct the hash (challenge)
+		let mut msg: Vec<&BigInt> = vec![&statement.h1, &statement.h2, &statement.N_tilde];
+		for i in 0..ITERATIONS {
+			msg.push(&self.Alpha[i]);
+		}
+
+		let mut hash = Sha512Trunc256::new();
+		for elt in msg.iter() {
+			hash = hash.chain_bigint(&elt);
+		}
+		let c: Vec<_> = hash
+			.result_bigint()
+			.to_bytes()
+			.into_iter()
+			.flat_map(|val| {
+				[
+					(val >> 7) & 1,
+					(val >> 6) & 1,
+					(val >> 5) & 1,
+					(val >> 4) & 1,
+					(val >> 3) & 1,
+					(val >> 2) & 1,
+					(val >> 1) & 1,
+					(val >> 0) & 1,
+				]
+				.into_iter()
+			})
+			.collect();
+
+		// Validate the zero-knowledge proof
+		for i in 0..ITERATIONS {
+			let c_i = BigInt::from(c[i] as u16);
+			let h1_exp_t_i = BigInt::mod_pow(&statement.h1, &self.T[i], &statement.N_tilde);
+			let h2_exp_c_i = BigInt::mod_pow(&statement.h2, &c_i, &statement.N_tilde);
+			let alpha_i_mul_h2_exp_c_i =
+				BigInt::mod_mul(&self.Alpha[i], &h2_exp_c_i, &statement.N_tilde);
+
+			println!("{:?}", i);
+			if h1_exp_t_i != alpha_i_mul_h2_exp_c_i {
+				return Err(DlnProofError::Verify)
+			}
+		}
+
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::utilities::{mta::range_proofs::SampleFromMultiplicativeGroup, BITS_PAILLIER};
+	use curv::elliptic::curves::secp256_k1::Secp256k1;
+	use paillier::{KeyGeneration, Paillier};
+	use sha2::Sha512Trunc256;
+
+	#[test]
+	fn test_discrete_log_proof() {
+		let statement = DlnProofStatement::generate();
+		let x = Scalar::<Secp256k1>::random();
+		let witness = DlnProofWitness { x: x.to_bigint() };
+		let proof = DlnProof::prove(&witness, &statement);
+		let result = proof.verify(&statement);
+		assert!(result.is_ok());
+	}
+}

--- a/src/utilities/log_star/mod.rs
+++ b/src/utilities/log_star/mod.rs
@@ -82,7 +82,7 @@ impl<E: Curve, H: Digest + Clone> KnowledgeOfExponentPaillierEncryptionStatement
 		let N0 = paillier_key.clone().n;
 		let NN0 = paillier_key.nn;
 		let x = BigInt::sample_range(&BigInt::from(-1).mul(&l_exp), &l_exp);
-		let g = g.unwrap_or(Point::<E>::generator().to_point());
+		let g = g.unwrap_or_else(|| Point::<E>::generator().to_point());
 		let X = &g * Scalar::from(&x);
 		let C: BigInt = Paillier::encrypt_with_chosen_randomness(
 			&EncryptionKey { n: N0.clone(), nn: NN0.clone() },

--- a/src/utilities/mod.rs
+++ b/src/utilities/mod.rs
@@ -5,6 +5,7 @@ use curv::{
 
 pub mod aff_g;
 pub mod dec_q;
+pub mod dlnproof;
 pub mod enc;
 pub mod log_star;
 pub mod mta;

--- a/src/utilities/sha2.rs
+++ b/src/utilities/sha2.rs
@@ -1,49 +1,50 @@
-//! Wrapper for the SHA2 Sha256 algorithm that implements 
+//! Wrapper for the SHA2 Sha256 algorithm that implements
 //! the serde Serialize and Deserialize traits.
-use serde::{Serialize, Deserialize};
 use digest::{Digest, Output};
 use generic_array::typenum::U32;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Sha256 {
-    #[serde(skip)]
-    inner: sha2::Sha256,
+	#[serde(skip)]
+	inner: sha2::Sha256,
 }
 
 impl Digest for Sha256 {
-    type OutputSize = U32;
+	type OutputSize = U32;
 
-    fn new() -> Self {
-        Self { inner: sha2::Sha256::new() }
-    }
+	fn new() -> Self {
+		Self { inner: sha2::Sha256::new() }
+	}
 
-    fn update(&mut self, data: impl AsRef<[u8]>) {
-        self.inner.update(data);
-    }
+	fn update(&mut self, data: impl AsRef<[u8]>) {
+		self.inner.update(data);
+	}
 
-    fn chain(self, data: impl AsRef<[u8]>) -> Self
-    where
-        Self: Sized {
-        Self { inner: self.inner.chain(data) } 
-    }
+	fn chain(self, data: impl AsRef<[u8]>) -> Self
+	where
+		Self: Sized,
+	{
+		Self { inner: self.inner.chain(data) }
+	}
 
-    fn finalize(self) -> Output<Self> {
-        self.inner.finalize()
-    }
+	fn finalize(self) -> Output<Self> {
+		self.inner.finalize()
+	}
 
-    fn finalize_reset(&mut self) -> Output<Self> {
-        self.inner.finalize_reset()
-    }
+	fn finalize_reset(&mut self) -> Output<Self> {
+		self.inner.finalize_reset()
+	}
 
-    fn reset(&mut self) {
-        self.inner.reset();
-    }
+	fn reset(&mut self) {
+		self.inner.reset();
+	}
 
-    fn output_size() -> usize {
-        sha2::Sha256::output_size()
-    }
+	fn output_size() -> usize {
+		sha2::Sha256::output_size()
+	}
 
-    fn digest(data: &[u8]) -> Output<Self> {
-        sha2::Sha256::digest(data)
-    }
+	fn digest(data: &[u8]) -> Output<Self> {
+		sha2::Sha256::digest(data)
+	}
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- c-split exploit fix from [tsshock](https://github.com/verichains/tsshock/blob/main/verichains-tsshock-wp-v1.0.pdf)
- implement new dlnproof w/ multi-iteration challenge process over challenge bits rather than sha256 hash.

### Description
https://www.verichains.io/tsshock/