### PR TITLE
fix: use all refresh msgs for combining new keyshares

### DIFF
--- a/fs-dkr/src/add_party_message.rs
+++ b/fs-dkr/src/add_party_message.rs
@@ -243,7 +243,7 @@ impl<E: Curve, H: Digest + Clone, const M: usize> JoinMessage<E, H, M> {
 
         #[allow(clippy::needless_range_loop)]
         for i in 0..new_n as usize {
-            for j in 1..refresh_messages.len() as usize {
+            for j in 1..refresh_messages.len() {
                 pk_vec[i] = pk_vec[i].clone()
                     + refresh_messages[j].points_committed_vec[i].clone()
                         * li_vec[j].clone();

--- a/fs-dkr/src/add_party_message.rs
+++ b/fs-dkr/src/add_party_message.rs
@@ -221,7 +221,6 @@ impl<E: Curve, H: Digest + Clone, const M: usize> JoinMessage<E, H, M> {
             party_index,
             &parameters,
             &paillier_key.ek,
-            current_t,
         );
         let new_share = Paillier::decrypt(&paillier_key.dk, cipher_text_sum)
             .0

--- a/fs-dkr/src/add_party_message.rs
+++ b/fs-dkr/src/add_party_message.rs
@@ -244,7 +244,7 @@ impl<E: Curve, H: Digest + Clone, const M: usize> JoinMessage<E, H, M> {
 
         #[allow(clippy::needless_range_loop)]
         for i in 0..new_n as usize {
-            for j in 1..(current_t + 1) as usize {
+            for j in 1..refresh_messages.len() as usize {
                 pk_vec[i] = pk_vec[i].clone()
                     + refresh_messages[j].points_committed_vec[i].clone()
                         * li_vec[j].clone();

--- a/fs-dkr/src/refresh_message.rs
+++ b/fs-dkr/src/refresh_message.rs
@@ -510,7 +510,7 @@ impl<E: Curve, H: Digest + Clone, const M: usize> RefreshMessage<E, H, M> {
                 refresh_messages[0].points_committed_vec[i].clone()
                     * li_vec[0].clone(),
             );
-            for j in 1..refresh_messages.len() as usize {
+            for j in 1..refresh_messages.len() {
                 local_key.pk_vec[i] = local_key.pk_vec[i].clone()
                     + refresh_messages[j].points_committed_vec[i].clone()
                         * li_vec[j].clone();

--- a/fs-dkr/src/refresh_message.rs
+++ b/fs-dkr/src/refresh_message.rs
@@ -217,7 +217,6 @@ impl<E: Curve, H: Digest + Clone, const M: usize> RefreshMessage<E, H, M> {
         party_index: u16,
         parameters: &'a ShamirSecretSharing,
         ek: &'a EncryptionKey,
-        current_t: u16,
     ) -> (RawCiphertext<'a>, Vec<Scalar<E>>) {
         // we first homomorphically add all ciphertext encrypted using our
         // encryption key
@@ -409,7 +408,6 @@ impl<E: Curve, H: Digest + Clone, const M: usize> RefreshMessage<E, H, M> {
             local_key.i,
             &local_key.vss_scheme.parameters,
             &old_ek,
-            current_t,
         );
 
         for refresh_message in refresh_messages.iter() {


### PR DESCRIPTION
**Summary of changes**

In FS-DKR subprotocol for key refresh, the parties secret share their current private share and send the corresponding shares to other parties who then recombine their shares to get their new private share.

However, in the current implementation, all parties only use first `current_t+1` received shares to combine their new secret share. The new private shares are valid (they are secret shared parts of the global private key) due to SS, but they do not include the contribution of all parties taking part in the key refresh round. This degrades the entropy of the private shares.

This PR changes the behaviour of the parties to take into account of all received messages. Additionally I removed the threshold argument in methods which do not need it anymore.

This PR corresponds to https://github.com/webb-tools/fs-dkr/pull/16 with also using all refresh messages in join messages.

The tests mostly succeed. May it be that https://github.com/webb-tools/cggmp-threshold-ecdsa/issues/28 affects also refresh tests?