### PR TITLE
Add and use fixed_array() function.

### DIFF
--- a/src/utilities/aff_g/mod.rs
+++ b/src/utilities/aff_g/mod.rs
@@ -36,7 +36,8 @@
 use super::sample_relatively_prime_integer;
 use crate::{
     utilities::{
-        mod_pow_with_negative, L, L_PLUS_EPSILON, L_PRIME, L_PRIME_PLUS_EPSILON,
+        mod_pow_with_negative, fixed_array, L, L_PLUS_EPSILON, L_PRIME,
+        L_PRIME_PLUS_EPSILON,
     },
     Error,
 };
@@ -307,7 +308,7 @@ impl<E: Curve, H: Digest + Clone>
             .chain_bigint(&F)
             .result_bigint();
         let mut rng: ChaChaRng =
-            ChaChaRng::from_seed(e.to_bytes().try_into().unwrap());
+            ChaChaRng::from_seed(fixed_array::<32>(e.to_bytes()).unwrap());
         let val = rng.gen_range(0..2);
         e = BigInt::from(val)
             .mul(&BigInt::from(-2))
@@ -371,7 +372,7 @@ impl<E: Curve, H: Digest + Clone>
             .chain_bigint(&proof.commitment.F.clone())
             .result_bigint();
         let mut rng: ChaChaRng =
-            ChaChaRng::from_seed(e.to_bytes().try_into().unwrap());
+            ChaChaRng::from_seed(fixed_array::<32>(e.to_bytes()).unwrap());
         let val = rng.gen_range(0..2);
         e = BigInt::from(val)
             .mul(&BigInt::from(-2))

--- a/src/utilities/aff_g/mod.rs
+++ b/src/utilities/aff_g/mod.rs
@@ -36,7 +36,7 @@
 use super::sample_relatively_prime_integer;
 use crate::{
     utilities::{
-        mod_pow_with_negative, fixed_array, L, L_PLUS_EPSILON, L_PRIME,
+        fixed_array, mod_pow_with_negative, L, L_PLUS_EPSILON, L_PRIME,
         L_PRIME_PLUS_EPSILON,
     },
     Error,

--- a/src/utilities/dec_q/mod.rs
+++ b/src/utilities/dec_q/mod.rs
@@ -17,7 +17,7 @@
 
 use super::{sample_relatively_prime_integer, L, L_PLUS_EPSILON};
 use crate::{
-    utilities::{mod_pow_with_negative, fixed_array},
+    utilities::{fixed_array, mod_pow_with_negative},
     Error,
 };
 use curv::{

--- a/src/utilities/dec_q/mod.rs
+++ b/src/utilities/dec_q/mod.rs
@@ -16,7 +16,10 @@
 */
 
 use super::{sample_relatively_prime_integer, L, L_PLUS_EPSILON};
-use crate::{utilities::mod_pow_with_negative, Error};
+use crate::{
+    utilities::{mod_pow_with_negative, fixed_array},
+    Error,
+};
 use curv::{
     arithmetic::{traits::*, Modulo},
     cryptographic_primitives::hashing::{Digest, DigestExt},
@@ -179,7 +182,7 @@ impl<E: Curve, H: Digest + Clone> PaillierDecryptionModQProof<E, H> {
             .chain_bigint(&big_T)
             .result_bigint();
         let mut rng: ChaChaRng =
-            ChaChaRng::from_seed(e.to_bytes().try_into().unwrap());
+            ChaChaRng::from_seed(fixed_array::<32>(e.to_bytes()).unwrap());
         let val = rng.gen_range(0..2);
         e = BigInt::from(val)
             .mul(&BigInt::from(-2))
@@ -223,7 +226,7 @@ impl<E: Curve, H: Digest + Clone> PaillierDecryptionModQProof<E, H> {
             .chain_bigint(&proof.commitment.big_T)
             .result_bigint();
         let mut rng: ChaChaRng =
-            ChaChaRng::from_seed(e.to_bytes().try_into().unwrap());
+            ChaChaRng::from_seed(fixed_array::<32>(e.to_bytes()).unwrap());
         let val = rng.gen_range(0..2);
         e = BigInt::from(val)
             .mul(&BigInt::from(-2))

--- a/src/utilities/mod.rs
+++ b/src/utilities/mod.rs
@@ -16,12 +16,12 @@ pub mod zk_pdl_with_slack;
 
 /// Extend or truncate a vector of bytes to a fixed length array.
 ///
-/// If the length is less than the target amount `N` leading zeroes 
+/// If the length is less than the target amount `N` leading zeroes
 /// are prepended, if the length exceeds `N` it is truncated.
 ///
-/// The `ChaChaRng::from_seed()` function requires a `[u8; 32]` but the 
-/// chaining of the BigInt's does not guarantee the length 
-/// of the underlying bytes so we use this to ensure we seed the RNG 
+/// The `ChaChaRng::from_seed()` function requires a `[u8; 32]` but the
+/// chaining of the BigInt's does not guarantee the length
+/// of the underlying bytes so we use this to ensure we seed the RNG
 /// using the correct number of bytes.
 pub fn fixed_array<const N: usize>(
     mut seed: Vec<u8>,

--- a/src/utilities/mod.rs
+++ b/src/utilities/mod.rs
@@ -14,6 +14,27 @@ pub mod sha2;
 pub mod zk_pdl;
 pub mod zk_pdl_with_slack;
 
+/// Extend or truncate a vector of bytes to a fixed length array.
+///
+/// If the length is less than the target amount `N` leading zeroes 
+/// are prepended, if the length exceeds `N` it is truncated.
+///
+/// The `ChaChaRng::from_seed()` function requires a `[u8; 32]` but the 
+/// chaining of the BigInt's does not guarantee the length 
+/// of the underlying bytes so we use this to ensure we seed the RNG 
+/// using the correct number of bytes.
+pub fn fixed_array<const N: usize>(
+    mut seed: Vec<u8>,
+) -> Result<[u8; 32], Vec<u8>> {
+    if seed.len() < N {
+        let padding = vec![0; N - seed.len()];
+        seed.splice(..0, padding.iter().cloned());
+    } else if seed.len() > N {
+        seed.truncate(N);
+    }
+    Ok(seed.try_into()?)
+}
+
 pub fn sample_relatively_prime_integer(n: &BigInt) -> BigInt {
     let mut sample = BigInt::sample_below(n);
     while BigInt::gcd(&sample, n) != BigInt::from(1) {

--- a/src/utilities/mod.rs
+++ b/src/utilities/mod.rs
@@ -26,13 +26,18 @@ pub mod zk_pdl_with_slack;
 pub fn fixed_array<const N: usize>(
     mut seed: Vec<u8>,
 ) -> Result<[u8; 32], Vec<u8>> {
-    if seed.len() < N {
-        let padding = vec![0; N - seed.len()];
-        seed.splice(..0, padding.iter().cloned());
-    } else if seed.len() > N {
-        seed.truncate(N);
+    use std::cmp::Ordering;
+    match seed.len().cmp(&N) {
+        Ordering::Greater => {
+            seed.truncate(N);
+        }
+        Ordering::Less => {
+            let padding = vec![0; N - seed.len()];
+            seed.splice(..0, padding.iter().cloned());
+        }
+        _ => {}
     }
-    Ok(seed.try_into()?)
+    seed.try_into()
 }
 
 pub fn sample_relatively_prime_integer(n: &BigInt) -> BigInt {

--- a/src/utilities/mul/mod.rs
+++ b/src/utilities/mul/mod.rs
@@ -17,7 +17,7 @@
 
 use super::sample_relatively_prime_integer;
 use crate::{
-    utilities::{mod_pow_with_negative, fixed_array},
+    utilities::{fixed_array, mod_pow_with_negative},
     Error,
 };
 use curv::{

--- a/src/utilities/mul/mod.rs
+++ b/src/utilities/mul/mod.rs
@@ -16,7 +16,10 @@
 */
 
 use super::sample_relatively_prime_integer;
-use crate::{utilities::mod_pow_with_negative, Error};
+use crate::{
+    utilities::{mod_pow_with_negative, fixed_array},
+    Error,
+};
 use curv::{
     arithmetic::{traits::*, Modulo},
     cryptographic_primitives::hashing::{Digest, DigestExt},
@@ -149,7 +152,7 @@ impl<E: Curve, H: Digest + Clone> PaillierMulProof<E, H> {
         // e = H(A,B)
         let mut e = H::new().chain_bigint(&A).chain_bigint(&B).result_bigint();
         let mut rng: ChaChaRng =
-            ChaChaRng::from_seed(e.to_bytes().try_into().unwrap());
+            ChaChaRng::from_seed(fixed_array::<32>(e.to_bytes()).unwrap());
         let val = rng.gen_range(0..2);
         e = BigInt::from(val)
             .mul(&BigInt::from(-2))
@@ -190,7 +193,7 @@ impl<E: Curve, H: Digest + Clone> PaillierMulProof<E, H> {
             .chain_bigint(&proof.commitment.B)
             .result_bigint();
         let mut rng: ChaChaRng =
-            ChaChaRng::from_seed(e.to_bytes().try_into().unwrap());
+            ChaChaRng::from_seed(fixed_array::<32>(e.to_bytes()).unwrap());
         let val = rng.gen_range(0..2);
         e = BigInt::from(val)
             .mul(&BigInt::from(-2))


### PR DESCRIPTION
To ensure that ChaChaRng is always presented with the correct number of bytes.

**Summary of changes**
Changes introduced in this pull request:
- Add the `fixed_array()` function which does an infallible conversion to `N` where `N` is typically 32
- Use `fixed_array()` wherever we seed `ChaChaRng`.

Closes #28
